### PR TITLE
fix: corrigir tipo do formatter do Tooltip para compatibilidade com R…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5867,6 +5867,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/orgao/[slug]/orgao-detail-client.tsx
+++ b/src/app/orgao/[slug]/orgao-detail-client.tsx
@@ -265,7 +265,7 @@ export function OrgaoDetailClient({ members, availableYears, currentYear }: Orga
                     width={35}
                   />
                   <Tooltip
-                    formatter={(value: number) => formatCurrency(value)}
+                    formatter={(value) => formatCurrency(Number(value))}
                     labelFormatter={(label) => `Estado: ${label}`}
                     contentStyle={{ fontSize: 12 }}
                   />


### PR DESCRIPTION
**Fix Recharts Tooltip formatter type error**

**Problem:**
The production build (npm run build) was failing with a TypeScript error in orgao-detail-client.tsx. The Tooltip component's formatter prop expected value to be number | undefined, but the callback explicitly typed it as number, causing a type incompatibility.

**Fix:**
Removed the explicit type annotation and wrapped the value with Number() to safely handle the potential undefined case, satisfying both TypeScript and Recharts' Formatter type signature.
Changed files:
src/app/orgao/[slug]/orgao-detail-client.tsx