### PR TITLE
Feat/comparativo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2175,6 +2176,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2966,6 +2968,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3073,9 +3076,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3088,6 +3091,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3153,6 +3157,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3307,9 +3312,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3320,9 +3325,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3810,6 +3815,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4145,6 +4151,7 @@
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4217,6 +4224,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5147,6 +5155,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5224,6 +5233,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7258,9 +7268,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7882,6 +7892,13 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -7952,6 +7969,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7961,6 +7979,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7969,16 +7988,18 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8055,7 +8076,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8968,6 +8990,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9671,6 +9694,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9848,6 +9872,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10440,6 +10465,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10702,6 +10728,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/anomalias/page.tsx
+++ b/src/app/anomalias/page.tsx
@@ -1,4 +1,4 @@
-import { getAnomalias, getAvailableYears } from "@/data/get-members";
+import { getAnomalias, getCachedAvailableYears } from "@/data/get-members";
 import { AnomaliasClient } from "./anomalias-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function AnomaliasPage({ searchParams }: Props) {
   const { ano, min } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
   const validAno = ano && isValidYear(ano) ? ano : undefined;
   const currentYear =
     validAno ||

--- a/src/app/comparativo/comparativo-client.tsx
+++ b/src/app/comparativo/comparativo-client.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, TrendingUp, TrendingDown, Minus, ChevronUp, ChevronDown } from "lucide-react";
+import { ArrowLeft, TrendingUp, TrendingDown, Minus, ChevronUp, ChevronDown, AlertTriangle } from "lucide-react";
 import { ShareButtons } from "@/components/share-buttons";
 import {
   BarChart,
@@ -35,6 +35,11 @@ interface ComparativoClientProps {
     };
   } | null;
   trend: YearComparisonData[];
+  yearMonthCounts: { year: number; monthCount: number }[];
+}
+
+function formatMillions(v: number): string {
+  return `${Math.round(v / 1_000_000)}M`;
 }
 
 function GrowthIndicator({ value }: { value: number }) {
@@ -105,13 +110,14 @@ export function ComparativoClient({
   availableYears,
   comparison,
   trend,
+  yearMonthCounts,
 }: ComparativoClientProps) {
   const router = useRouter();
   const [showAllOrgaos, setShowAllOrgaos] = useState(false);
 
   type SortKey = "orgao" | "y1" | "y2" | "variation";
   type SortDir = "asc" | "desc";
-  const [sortBy, setSortBy] = useState<SortKey>("y2");
+  const [sortBy, setSortBy] = useState<SortKey>("y1");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const handleSort = (key: SortKey) => {
@@ -123,22 +129,34 @@ export function ComparativoClient({
     }
   };
 
+  const yearMonthMap = new Map(yearMonthCounts.map((y) => [y.year, y.monthCount]));
+  const currentYear = new Date().getFullYear();
+  const incompleteYears = yearMonthCounts
+    .filter((y) => y.monthCount < 12)
+    .map((y) => ({
+      year: y.year,
+      monthCount: y.monthCount,
+      isCurrentYear: y.year === currentYear,
+    }));
+
+  const getMonthCountWarning = (year: number) => {
+    const count = yearMonthMap.get(year);
+    if (!count || count >= 12) return null;
+    const isCurrent = year === currentYear;
+    return { count, isCurrent };
+  };
+
   const comparisonData = comparison
     ? [
         {
-          name: "Total Acima do Teto",
-          [year1]: comparison.year1.totalAboveTeto,
-          [year2]: comparison.year2.totalAboveTeto,
-        },
-        {
-          name: "Membros Acima",
-          [year1]: comparison.year1.membersAboveTeto,
-          [year2]: comparison.year2.membersAboveTeto,
+          name: "Membros Acima do Teto",
+          year1Val: comparison.year1.membersAboveTeto,
+          year2Val: comparison.year2.membersAboveTeto,
         },
         {
           name: "Média por Membro",
-          [year1]: comparison.year1.averageAboveTeto,
-          [year2]: comparison.year2.averageAboveTeto,
+          year1Val: comparison.year1.averageAboveTeto,
+          year2Val: comparison.year2.averageAboveTeto,
         },
       ]
     : [];
@@ -146,7 +164,7 @@ export function ComparativoClient({
   const trendData = trend.map((t) => ({
     year: t.year,
     "Total Acima do Teto": t.totalAboveTeto,
-    "Membros Acima": t.membersAboveTeto,
+    "Membros Acima do Teto": t.membersAboveTeto,
     "Média por Membro": t.averageAboveTeto,
   }));
 
@@ -233,6 +251,23 @@ export function ComparativoClient({
           </div>
         </div>
 
+        {/* Warning about incomplete years */}
+        {incompleteYears.length > 0 && (
+          <div className="mb-4 flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div>
+              <span className="font-medium">Nota: </span>
+              {incompleteYears.map((y, i) => (
+                <span key={y.year}>
+                  {i > 0 && ", "}
+                  O ano de {y.year} possui dados de {y.monthCount} mês{y.monthCount > 1 ? "es" : ""}
+                  {y.isCurrentYear ? " (esperado para ano atual)" : " (incompleto)"}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Section Label: Historical Trend */}
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">
           Tendência Histórica
@@ -252,7 +287,7 @@ export function ComparativoClient({
                   <YAxis
                     yAxisId="left"
                     tick={{ fontSize: 10, fill: "#94A3B8" }}
-                    tickFormatter={(v) => `${(v / 1_000_000).toFixed(0)}M`}
+                    tickFormatter={formatMillions}
                   />
                   <YAxis
                     yAxisId="right"
@@ -260,8 +295,11 @@ export function ComparativoClient({
                     tick={{ fontSize: 10, fill: "#94A3B8" }}
                   />
                   <Tooltip
-                    formatter={(value) => {
+                    formatter={(value, name) => {
                       const numValue = Number(value);
+                      if (name === "Membros Acima do Teto") {
+                        return formatNumber(numValue);
+                      }
                       if (numValue > 1000000) {
                         return formatCompactCurrency(numValue);
                       }
@@ -280,7 +318,7 @@ export function ComparativoClient({
                   <Line
                     yAxisId="right"
                     type="monotone"
-                    dataKey="Membros Acima"
+                    dataKey="Membros Acima do Teto"
                     stroke="#3B82F6"
                     strokeWidth={2}
                     dot={{ r: 4, fill: "#3B82F6" }}
@@ -310,6 +348,14 @@ export function ComparativoClient({
                 </option>
               ))}
             </select>
+            {getMonthCountWarning(year1) && (
+              <div 
+                className="flex items-center" 
+                title={getMonthCountWarning(year1)?.isCurrent ? `Dados de ${getMonthCountWarning(year1)?.count} meses (esperado para ano atual)` : `Dados de ${getMonthCountWarning(year1)?.count} meses (incompleto)`}
+              >
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+              </div>
+            )}
           </div>
           <span className="text-gray-400">vs</span>
           <div className="flex items-center gap-2">
@@ -324,6 +370,14 @@ export function ComparativoClient({
                 </option>
               ))}
             </select>
+            {getMonthCountWarning(year2) && (
+              <div 
+                className="flex items-center" 
+                title={getMonthCountWarning(year2)?.isCurrent ? `Dados de ${getMonthCountWarning(year2)?.count} meses (esperado para ano atual)` : `Dados de ${getMonthCountWarning(year2)?.count} meses (incompleto)`}
+              >
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+              </div>
+            )}
           </div>
         </div>
 
@@ -383,7 +437,7 @@ export function ComparativoClient({
         {/* Comparison Chart */}
         <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
           <h2 className="mb-4 font-serif text-lg font-bold text-navy">
-            Comparação entre {year1} e {year2}
+            Comparação de membros entre {year1} e {year2}
           </h2>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
@@ -393,7 +447,11 @@ export function ComparativoClient({
                 margin={{ left: 120, right: 30 }}
               >
                 <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                <XAxis type="number" tick={{ fontSize: 10, fill: "#94A3B8" }} />
+                <XAxis 
+                  type="number" 
+                  tick={{ fontSize: 10, fill: "#94A3B8" }}
+                  tickFormatter={formatMillions}
+                />
                 <YAxis
                   type="category"
                   dataKey="name"
@@ -401,17 +459,35 @@ export function ComparativoClient({
                   width={110}
                 />
                 <Tooltip
-                  formatter={(value) => {
-                    const numValue = Number(value);
-                    if (numValue > 1000) {
-                      return formatCurrency(numValue);
-                    }
-                    return formatNumber(numValue);
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    
+                    const dataName = payload[0]?.payload?.name;
+                    
+                    return (
+                      <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                        <div className="mb-2 font-medium text-gray-700">{dataName}</div>
+                        {payload.map((entry) => (
+                          <div key={entry.dataKey} className="flex items-center gap-2 text-sm">
+                            <span 
+                              className="h-2.5 w-2.5 rounded-full" 
+                              style={{ backgroundColor: entry.color }}
+                            />
+                            <span className="text-gray-500">{entry.name}:</span>
+                            <span className="font-medium text-gray-700">
+                              {dataName === "Membros Acima do Teto" 
+                                ? formatNumber(Number(entry.value)) 
+                                : formatCurrency(Number(entry.value))}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    );
                   }}
                 />
                 <Legend />
-                <Bar dataKey={year1} fill="#94A3B8" name={String(year1)} radius={[0, 4, 4, 0]} />
-                <Bar dataKey={year2} fill="#DC2626" name={String(year2)} radius={[0, 4, 4, 0]} />
+                <Bar dataKey="year1Val" fill="#94A3B8" name={String(year1)} radius={[0, 4, 4, 0]} />
+                <Bar dataKey="year2Val" fill="#DC2626" name={String(year2)} radius={[0, 4, 4, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -493,7 +569,7 @@ export function ComparativoClient({
           {allOrgaos.length > 5 && (
             <button
               onClick={() => setShowAllOrgaos(!showAllOrgaos)}
-              className="mt-3 flex items-center gap-1 text-sm text-blue-600 hover:underline"
+              className="mt-3 flex cursor-pointer items-center gap-1 text-sm text-blue-600 hover:underline"
             >
               {showAllOrgaos ? (
                 <>

--- a/src/app/comparativo/comparativo-client.tsx
+++ b/src/app/comparativo/comparativo-client.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { ArrowLeft, TrendingUp, TrendingDown, Minus, ChevronUp, ChevronDown } from "lucide-react";
 import { ShareButtons } from "@/components/share-buttons";
 import {
   BarChart,
@@ -40,7 +40,7 @@ interface ComparativoClientProps {
 function GrowthIndicator({ value }: { value: number }) {
   if (value > 0) {
     return (
-      <span className="flex items-center gap-1 text-sm font-bold text-red-600">
+      <span className="flex items-center justify-end gap-1 text-sm font-bold text-red-600">
         <TrendingUp className="h-4 w-4" />
         +{value.toFixed(1)}%
       </span>
@@ -48,14 +48,14 @@ function GrowthIndicator({ value }: { value: number }) {
   }
   if (value < 0) {
     return (
-      <span className="flex items-center gap-1 text-sm font-bold text-green-600">
+      <span className="flex items-center justify-end gap-1 text-sm font-bold text-green-600">
         <TrendingDown className="h-4 w-4" />
         {value.toFixed(1)}%
       </span>
     );
   }
   return (
-    <span className="flex items-center gap-1 text-sm font-bold text-gray-500">
+    <span className="flex items-center justify-end gap-1 text-sm font-bold text-gray-500">
       <Minus className="h-4 w-4" />
       0%
     </span>
@@ -107,6 +107,21 @@ export function ComparativoClient({
   trend,
 }: ComparativoClientProps) {
   const router = useRouter();
+  const [showAllOrgaos, setShowAllOrgaos] = useState(false);
+
+  type SortKey = "orgao" | "y1" | "y2" | "variation";
+  type SortDir = "asc" | "desc";
+  const [sortBy, setSortBy] = useState<SortKey>("y2");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const handleSort = (key: SortKey) => {
+    if (sortBy === key) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortBy(key);
+      setSortDir(key === "orgao" ? "asc" : "desc");
+    }
+  };
 
   const comparisonData = comparison
     ? [
@@ -143,20 +158,37 @@ export function ComparativoClient({
     }
   }
 
-  const topOrgansTable = useMemo(() => {
+  const allOrgaos = useMemo(() => {
     if (!comparison) return [];
     const y1Map = new Map(comparison.year1.topOrgans.map((o) => [o.orgao, o.total]));
     const y2Map = new Map(comparison.year2.topOrgans.map((o) => [o.orgao, o.total]));
-    const allOrgaos = new Set([...y1Map.keys(), ...y2Map.keys()]);
-    return Array.from(allOrgaos)
+    const allOrgaosSet = new Set([...y1Map.keys(), ...y2Map.keys()]);
+    const mapped = Array.from(allOrgaosSet)
       .map((orgao) => ({
         orgao,
         y1: y1Map.get(orgao) || 0,
         y2: y2Map.get(orgao) || 0,
+        variation: 0,
       }))
-      .sort((a, b) => b.y2 - a.y2)
-      .slice(0, 5);
-  }, [comparison]);
+      .map((row) => ({
+        ...row,
+        variation: row.y1 > 0 ? ((row.y2 - row.y1) / row.y1) * 100 : 0,
+      }));
+
+    return mapped.sort((a, b) => {
+      const modifier = sortDir === "asc" ? 1 : -1;
+      if (sortBy === "orgao") {
+        return a.orgao.localeCompare(b.orgao, "pt-BR") * modifier;
+      }
+      const aVal = a[sortBy] as number;
+      const bVal = b[sortBy] as number;
+      return (aVal - bVal) * modifier;
+    });
+  }, [comparison, sortBy, sortDir]);
+
+  const topOrgansTable = useMemo(() => {
+    return showAllOrgaos ? allOrgaos : allOrgaos.slice(0, 5);
+  }, [allOrgaos, showAllOrgaos]);
 
   if (!comparison) {
     return (
@@ -201,10 +233,72 @@ export function ComparativoClient({
           </div>
         </div>
 
+        {/* Section Label: Historical Trend */}
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">
+          Tendência Histórica
+        </h2>
+
+        {/* Trend Chart - shows all years, placed before year selectors */}
+        {trendData.length > 1 && (
+          <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
+            <h2 className="mb-4 font-serif text-lg font-bold text-navy">
+              Evolução ao Longo dos Anos
+            </h2>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={trendData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis dataKey="year" tick={{ fontSize: 11, fill: "#94A3B8" }} />
+                  <YAxis
+                    yAxisId="left"
+                    tick={{ fontSize: 10, fill: "#94A3B8" }}
+                    tickFormatter={(v) => `${(v / 1_000_000).toFixed(0)}M`}
+                  />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tick={{ fontSize: 10, fill: "#94A3B8" }}
+                  />
+                  <Tooltip
+                    formatter={(value) => {
+                      const numValue = Number(value);
+                      if (numValue > 1000000) {
+                        return formatCompactCurrency(numValue);
+                      }
+                      return formatNumber(numValue);
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="Total Acima do Teto"
+                    stroke="#DC2626"
+                    strokeWidth={2}
+                    dot={{ r: 4, fill: "#DC2626" }}
+                  />
+                  <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="Membros Acima"
+                    stroke="#3B82F6"
+                    strokeWidth={2}
+                    dot={{ r: 4, fill: "#3B82F6" }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </section>
+        )}
+
+        {/* Section Label: Selected Years Comparison */}
+        <h2 className="mt-8 text-sm font-semibold uppercase tracking-wider text-gray-500">
+          Comparativo específico
+        </h2>
+
         {/* Year Selectors */}
         <div className="mb-6 flex flex-wrap items-center justify-center gap-4">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-600">Ano 1:</span>
             <select
               value={year1}
               onChange={(e) => handleYearChange("ano1", e.target.value)}
@@ -219,7 +313,6 @@ export function ComparativoClient({
           </div>
           <span className="text-gray-400">vs</span>
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-600">Ano 2:</span>
             <select
               value={year2}
               onChange={(e) => handleYearChange("ano2", e.target.value)}
@@ -324,78 +417,63 @@ export function ComparativoClient({
           </div>
         </section>
 
-        {/* Trend Chart */}
-        {trendData.length > 1 && (
-          <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
-            <h2 className="mb-4 font-serif text-lg font-bold text-navy">
-              Evolução ao Longo dos Anos
-            </h2>
-            <div className="h-80">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={trendData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                  <XAxis dataKey="year" tick={{ fontSize: 11, fill: "#94A3B8" }} />
-                  <YAxis
-                    yAxisId="left"
-                    tick={{ fontSize: 10, fill: "#94A3B8" }}
-                    tickFormatter={(v) => `${(v / 1_000_000).toFixed(0)}M`}
-                  />
-                  <YAxis
-                    yAxisId="right"
-                    orientation="right"
-                    tick={{ fontSize: 10, fill: "#94A3B8" }}
-                  />
-                  <Tooltip
-                    formatter={(value) => {
-                      const numValue = Number(value);
-                      if (numValue > 1000000) {
-                        return formatCompactCurrency(numValue);
-                      }
-                      return formatNumber(numValue);
-                    }}
-                  />
-                  <Legend />
-                  <Line
-                    yAxisId="left"
-                    type="monotone"
-                    dataKey="Total Acima do Teto"
-                    stroke="#DC2626"
-                    strokeWidth={2}
-                    dot={{ r: 4, fill: "#DC2626" }}
-                  />
-                  <Line
-                    yAxisId="right"
-                    type="monotone"
-                    dataKey="Membros Acima"
-                    stroke="#3B82F6"
-                    strokeWidth={2}
-                    dot={{ r: 4, fill: "#3B82F6" }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </section>
-        )}
-
         {/* Top Organs Table */}
         <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
           <h2 className="mb-4 font-serif text-lg font-bold text-navy">
-            Top 5 Órgãos por Total Acima do Teto
+            Órgãos por Total Acima do Teto
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
-                  <th className="pb-2 text-left font-semibold text-gray-600">Órgão</th>
-                  <th className="pb-2 text-right font-semibold text-gray-600">{year1}</th>
-                  <th className="pb-2 text-right font-semibold text-gray-600">{year2}</th>
-                  <th className="pb-2 text-right font-semibold text-gray-600">Variação</th>
+                  <th
+                    className="cursor-pointer pb-2 text-left font-semibold text-gray-600 transition-colors hover:text-navy"
+                    onClick={() => handleSort("orgao")}
+                  >
+                    <span className="flex items-center gap-1">
+                      Órgão
+                      {sortBy === "orgao" && (
+                        sortDir === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+                      )}
+                    </span>
+                  </th>
+                  <th
+                    className="cursor-pointer pb-2 text-right font-semibold text-gray-600 transition-colors hover:text-navy"
+                    onClick={() => handleSort("y1")}
+                  >
+                    <span className="flex items-center justify-end gap-1">
+                      {year1}
+                      {sortBy === "y1" && (
+                        sortDir === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+                      )}
+                    </span>
+                  </th>
+                  <th
+                    className="cursor-pointer pb-2 text-right font-semibold text-gray-600 transition-colors hover:text-navy"
+                    onClick={() => handleSort("y2")}
+                  >
+                    <span className="flex items-center justify-end gap-1">
+                      {year2}
+                      {sortBy === "y2" && (
+                        sortDir === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+                      )}
+                    </span>
+                  </th>
+                  <th
+                    className="cursor-pointer pb-2 text-right font-semibold text-gray-600 transition-colors hover:text-navy"
+                    onClick={() => handleSort("variation")}
+                  >
+                    <span className="flex items-center justify-end gap-1">
+                      Variação
+                      {sortBy === "variation" && (
+                        sortDir === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+                      )}
+                    </span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {topOrgansTable.map((row) => {
-                  const variation = row.y1 > 0 ? ((row.y2 - row.y1) / row.y1) * 100 : 0;
-                  return (
+                {topOrgansTable.map((row) => (
                     <tr key={row.orgao} className="border-b border-gray-50 last:border-0">
                       <td className="py-2 font-medium text-navy">{row.orgao}</td>
                       <td className="py-2 text-right text-gray-600">
@@ -405,14 +483,31 @@ export function ComparativoClient({
                         {formatCompactCurrency(row.y2)}
                       </td>
                       <td className="py-2 text-right">
-                        <GrowthIndicator value={variation} />
+                        <GrowthIndicator value={row.variation} />
                       </td>
                     </tr>
-                  );
-                })}
+                  ))}
               </tbody>
             </table>
           </div>
+          {allOrgaos.length > 5 && (
+            <button
+              onClick={() => setShowAllOrgaos(!showAllOrgaos)}
+              className="mt-3 flex items-center gap-1 text-sm text-blue-600 hover:underline"
+            >
+              {showAllOrgaos ? (
+                <>
+                  <ChevronUp className="h-4 w-4" />
+                  Ver menos
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" />
+                  Ver todos os {allOrgaos.length} órgãos
+                </>
+              )}
+            </button>
+          )}
         </section>
       </div>
       <Footer />

--- a/src/app/comparativo/comparativo-client.tsx
+++ b/src/app/comparativo/comparativo-client.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { ShareButtons } from "@/components/share-buttons";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  Legend,
+} from "recharts";
+import type { YearComparisonData } from "@/data/get-members";
+import { formatCurrency, formatCompactCurrency, formatNumber } from "@/lib/utils";
+import { Footer } from "@/components/footer";
+
+interface ComparativoClientProps {
+  year1: number;
+  year2: number;
+  availableYears: { value: string; label: string }[];
+  comparison: {
+    year1: YearComparisonData;
+    year2: YearComparisonData;
+    growth: {
+      membersAboveTeto: number;
+      totalAboveTeto: number;
+      averageAboveTeto: number;
+    };
+  } | null;
+  trend: YearComparisonData[];
+}
+
+function GrowthIndicator({ value }: { value: number }) {
+  if (value > 0) {
+    return (
+      <span className="flex items-center gap-1 text-sm font-bold text-red-600">
+        <TrendingUp className="h-4 w-4" />
+        +{value.toFixed(1)}%
+      </span>
+    );
+  }
+  if (value < 0) {
+    return (
+      <span className="flex items-center gap-1 text-sm font-bold text-green-600">
+        <TrendingDown className="h-4 w-4" />
+        {value.toFixed(1)}%
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1 text-sm font-bold text-gray-500">
+      <Minus className="h-4 w-4" />
+      0%
+    </span>
+  );
+}
+
+function KPICard({
+  label,
+  year1Value,
+  year2Value,
+  year1Label,
+  year2Label,
+  growth,
+  format,
+}: {
+  label: string;
+  year1Value: number;
+  year2Value: number;
+  year1Label: string;
+  year2Label: string;
+  growth: number;
+  format: (v: number) => string;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+      <span className="text-xs font-semibold text-gray-600">{label}</span>
+      <div className="mt-2 flex items-baseline justify-between">
+        <div className="flex flex-col">
+          <span className="text-lg font-bold text-gray-400">{year1Label}</span>
+          <span className="text-xl font-bold text-navy">{format(year1Value)}</span>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-lg font-bold text-gray-400">{year2Label}</span>
+          <span className="text-xl font-bold text-navy">{format(year2Value)}</span>
+        </div>
+      </div>
+      <div className="mt-3 flex justify-center">
+        <GrowthIndicator value={growth} />
+      </div>
+    </div>
+  );
+}
+
+export function ComparativoClient({
+  year1,
+  year2,
+  availableYears,
+  comparison,
+  trend,
+}: ComparativoClientProps) {
+  const router = useRouter();
+
+  const comparisonData = comparison
+    ? [
+        {
+          name: "Total Acima do Teto",
+          [year1]: comparison.year1.totalAboveTeto,
+          [year2]: comparison.year2.totalAboveTeto,
+        },
+        {
+          name: "Membros Acima",
+          [year1]: comparison.year1.membersAboveTeto,
+          [year2]: comparison.year2.membersAboveTeto,
+        },
+        {
+          name: "Média por Membro",
+          [year1]: comparison.year1.averageAboveTeto,
+          [year2]: comparison.year2.averageAboveTeto,
+        },
+      ]
+    : [];
+
+  const trendData = trend.map((t) => ({
+    year: t.year,
+    "Total Acima do Teto": t.totalAboveTeto,
+    "Membros Acima": t.membersAboveTeto,
+    "Média por Membro": t.averageAboveTeto,
+  }));
+
+  function handleYearChange(yearParam: string, newYear: string) {
+    if (yearParam === "ano1") {
+      router.push(`/comparativo?ano1=${newYear}&ano2=${year2}`);
+    } else {
+      router.push(`/comparativo?ano1=${year1}&ano2=${newYear}`);
+    }
+  }
+
+  const topOrgansTable = useMemo(() => {
+    if (!comparison) return [];
+    const y1Map = new Map(comparison.year1.topOrgans.map((o) => [o.orgao, o.total]));
+    const y2Map = new Map(comparison.year2.topOrgans.map((o) => [o.orgao, o.total]));
+    const allOrgaos = new Set([...y1Map.keys(), ...y2Map.keys()]);
+    return Array.from(allOrgaos)
+      .map((orgao) => ({
+        orgao,
+        y1: y1Map.get(orgao) || 0,
+        y2: y2Map.get(orgao) || 0,
+      }))
+      .sort((a, b) => b.y2 - a.y2)
+      .slice(0, 5);
+  }, [comparison]);
+
+  if (!comparison) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <Link
+            href="/"
+            className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Voltar ao ranking
+          </Link>
+          <div className="rounded-lg border border-gray-100 bg-white p-8 text-center">
+            <p className="text-gray-500">Dados não disponíveis para comparação.</p>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <Link
+          href="/"
+          className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Voltar ao ranking
+        </Link>
+
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <TrendingUp className="h-6 w-6 text-red-primary" />
+            <h1 className="font-serif text-2xl font-bold text-navy sm:text-3xl">
+              Comparativo Anual
+            </h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <ShareButtons title="ExtraTeto — Comparativo Anual" />
+          </div>
+        </div>
+
+        {/* Year Selectors */}
+        <div className="mb-6 flex flex-wrap items-center justify-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">Ano 1:</span>
+            <select
+              value={year1}
+              onChange={(e) => handleYearChange("ano1", e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-navy shadow-sm focus:border-navy focus:outline-none focus:ring-1 focus:ring-navy"
+            >
+              {availableYears.map((y) => (
+                <option key={y.value} value={y.value}>
+                  {y.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <span className="text-gray-400">vs</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">Ano 2:</span>
+            <select
+              value={year2}
+              onChange={(e) => handleYearChange("ano2", e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-navy shadow-sm focus:border-navy focus:outline-none focus:ring-1 focus:ring-navy"
+            >
+              {availableYears.map((y) => (
+                <option key={y.value} value={y.value}>
+                  {y.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* KPI Cards */}
+        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <KPICard
+            label="Total Acima do Teto"
+            year1Value={comparison.year1.totalAboveTeto}
+            year2Value={comparison.year2.totalAboveTeto}
+            year1Label={String(year1)}
+            year2Label={String(year2)}
+            growth={comparison.growth.totalAboveTeto}
+            format={formatCompactCurrency}
+          />
+          <KPICard
+            label="Membros Acima do Teto"
+            year1Value={comparison.year1.membersAboveTeto}
+            year2Value={comparison.year2.membersAboveTeto}
+            year1Label={String(year1)}
+            year2Label={String(year2)}
+            growth={comparison.growth.membersAboveTeto}
+            format={formatNumber}
+          />
+          <KPICard
+            label="Média por Membro"
+            year1Value={comparison.year1.averageAboveTeto}
+            year2Value={comparison.year2.averageAboveTeto}
+            year1Label={String(year1)}
+            year2Label={String(year2)}
+            growth={comparison.growth.averageAboveTeto}
+            format={formatCurrency}
+          />
+          <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+            <span className="text-xs font-semibold text-gray-600">
+              Crescimento Total
+            </span>
+            <div className="mt-2 flex items-baseline justify-between">
+              <div className="flex flex-col">
+                <span className="text-lg font-bold text-gray-400">{year1}</span>
+                <span className="text-xl font-bold text-navy">
+                  {formatCompactCurrency(comparison.year1.totalAboveTeto)}
+                </span>
+              </div>
+              <div className="flex flex-col items-end">
+                <span className="text-lg font-bold text-gray-400">{year2}</span>
+                <span className="text-xl font-bold text-navy">
+                  {formatCompactCurrency(comparison.year2.totalAboveTeto)}
+                </span>
+              </div>
+            </div>
+            <div className="mt-3 flex justify-center">
+              <GrowthIndicator value={comparison.growth.totalAboveTeto} />
+            </div>
+          </div>
+        </div>
+
+        {/* Comparison Chart */}
+        <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
+          <h2 className="mb-4 font-serif text-lg font-bold text-navy">
+            Comparação entre {year1} e {year2}
+          </h2>
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={comparisonData}
+                layout="vertical"
+                margin={{ left: 120, right: 30 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis type="number" tick={{ fontSize: 10, fill: "#94A3B8" }} />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  tick={{ fontSize: 11, fill: "#64748B" }}
+                  width={110}
+                />
+                <Tooltip
+                  formatter={(value) => {
+                    const numValue = Number(value);
+                    if (numValue > 1000) {
+                      return formatCurrency(numValue);
+                    }
+                    return formatNumber(numValue);
+                  }}
+                />
+                <Legend />
+                <Bar dataKey={year1} fill="#94A3B8" name={String(year1)} radius={[0, 4, 4, 0]} />
+                <Bar dataKey={year2} fill="#DC2626" name={String(year2)} radius={[0, 4, 4, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+
+        {/* Trend Chart */}
+        {trendData.length > 1 && (
+          <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
+            <h2 className="mb-4 font-serif text-lg font-bold text-navy">
+              Evolução ao Longo dos Anos
+            </h2>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={trendData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis dataKey="year" tick={{ fontSize: 11, fill: "#94A3B8" }} />
+                  <YAxis
+                    yAxisId="left"
+                    tick={{ fontSize: 10, fill: "#94A3B8" }}
+                    tickFormatter={(v) => `${(v / 1_000_000).toFixed(0)}M`}
+                  />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tick={{ fontSize: 10, fill: "#94A3B8" }}
+                  />
+                  <Tooltip
+                    formatter={(value) => {
+                      const numValue = Number(value);
+                      if (numValue > 1000000) {
+                        return formatCompactCurrency(numValue);
+                      }
+                      return formatNumber(numValue);
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="Total Acima do Teto"
+                    stroke="#DC2626"
+                    strokeWidth={2}
+                    dot={{ r: 4, fill: "#DC2626" }}
+                  />
+                  <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="Membros Acima"
+                    stroke="#3B82F6"
+                    strokeWidth={2}
+                    dot={{ r: 4, fill: "#3B82F6" }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </section>
+        )}
+
+        {/* Top Organs Table */}
+        <section className="mb-6 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
+          <h2 className="mb-4 font-serif text-lg font-bold text-navy">
+            Top 5 Órgãos por Total Acima do Teto
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-100">
+                  <th className="pb-2 text-left font-semibold text-gray-600">Órgão</th>
+                  <th className="pb-2 text-right font-semibold text-gray-600">{year1}</th>
+                  <th className="pb-2 text-right font-semibold text-gray-600">{year2}</th>
+                  <th className="pb-2 text-right font-semibold text-gray-600">Variação</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topOrgansTable.map((row) => {
+                  const variation = row.y1 > 0 ? ((row.y2 - row.y1) / row.y1) * 100 : 0;
+                  return (
+                    <tr key={row.orgao} className="border-b border-gray-50 last:border-0">
+                      <td className="py-2 font-medium text-navy">{row.orgao}</td>
+                      <td className="py-2 text-right text-gray-600">
+                        {formatCompactCurrency(row.y1)}
+                      </td>
+                      <td className="py-2 text-right font-bold text-navy">
+                        {formatCompactCurrency(row.y2)}
+                      </td>
+                      <td className="py-2 text-right">
+                        <GrowthIndicator value={variation} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/comparativo/page.tsx
+++ b/src/app/comparativo/page.tsx
@@ -1,4 +1,4 @@
-import { getYearComparison, getCachedAllYearsTrend, getCachedAvailableYears, type YearComparisonData } from "@/data/get-members";
+import { getYearComparison, getCachedAllYearsTrend, getCachedAvailableYears, getCachedYearMonthCounts } from "@/data/get-members";
 import { ComparativoClient } from "./comparativo-client";
 
 interface Props {
@@ -22,6 +22,7 @@ export default async function ComparativoPage({ searchParams }: Props) {
 
   const comparison = getYearComparison(year1, year2);
   const trend = await getCachedAllYearsTrend();
+  const yearMonthCounts = await getCachedYearMonthCounts();
 
   return (
     <ComparativoClient
@@ -30,6 +31,7 @@ export default async function ComparativoPage({ searchParams }: Props) {
       availableYears={availableYears}
       comparison={comparison}
       trend={trend}
+      yearMonthCounts={yearMonthCounts}
     />
   );
 }

--- a/src/app/comparativo/page.tsx
+++ b/src/app/comparativo/page.tsx
@@ -1,4 +1,4 @@
-import { getYearComparison, getAllYearsTrend, getAvailableYears, type YearComparisonData } from "@/data/get-members";
+import { getYearComparison, getCachedAllYearsTrend, getCachedAvailableYears, type YearComparisonData } from "@/data/get-members";
 import { ComparativoClient } from "./comparativo-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function ComparativoPage({ searchParams }: Props) {
   const { ano1, ano2 } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
 
   const years = availableYears.map((y) => parseInt(y.value));
   const defaultYear1 = years.length >= 2 ? years[1] : years[0];
@@ -21,7 +21,7 @@ export default async function ComparativoPage({ searchParams }: Props) {
   const year2 = ano2 && isValidYear(ano2) ? parseInt(ano2) : defaultYear2;
 
   const comparison = getYearComparison(year1, year2);
-  const trend = getAllYearsTrend();
+  const trend = await getCachedAllYearsTrend();
 
   return (
     <ComparativoClient

--- a/src/app/comparativo/page.tsx
+++ b/src/app/comparativo/page.tsx
@@ -1,0 +1,35 @@
+import { getYearComparison, getAllYearsTrend, getAvailableYears, type YearComparisonData } from "@/data/get-members";
+import { ComparativoClient } from "./comparativo-client";
+
+interface Props {
+  searchParams: Promise<{ ano1?: string; ano2?: string }>;
+}
+
+function isValidYear(ano: string): boolean {
+  return /^\d{4}$/.test(ano);
+}
+
+export default async function ComparativoPage({ searchParams }: Props) {
+  const { ano1, ano2 } = await searchParams;
+  const availableYears = getAvailableYears();
+
+  const years = availableYears.map((y) => parseInt(y.value));
+  const defaultYear1 = years.length >= 2 ? years[1] : years[0];
+  const defaultYear2 = years[0];
+
+  const year1 = ano1 && isValidYear(ano1) ? parseInt(ano1) : defaultYear1;
+  const year2 = ano2 && isValidYear(ano2) ? parseInt(ano2) : defaultYear2;
+
+  const comparison = getYearComparison(year1, year2);
+  const trend = getAllYearsTrend();
+
+  return (
+    <ComparativoClient
+      year1={year1}
+      year2={year2}
+      availableYears={availableYears}
+      comparison={comparison}
+      trend={trend}
+    />
+  );
+}

--- a/src/app/estatisticas/page.tsx
+++ b/src/app/estatisticas/page.tsx
@@ -1,4 +1,4 @@
-import { getMembersByYear, getAvailableYears } from "@/data/get-members";
+import { getMembersByYear, getCachedAvailableYears } from "@/data/get-members";
 import { EstatisticasClient } from "./estatisticas-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function EstatisticasPage({ searchParams }: Props) {
   const { ano } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
   const validAno = ano && isValidYear(ano) ? ano : undefined;
   const currentYear = validAno || (availableYears.find((y) => y.value === "2025")?.value) || (availableYears.length > 0 ? availableYears[0].value : "2025");
   const members = getMembersByYear(currentYear);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,6 +65,7 @@ export default function RootLayout({
       <head />
       <body
         className={`${playfair.variable} ${dmSans.variable} font-sans antialiased`}
+        suppressHydrationWarning
       >
         <JsonLd data={getWebsiteJsonLd()} />
         <JsonLd data={getDatasetJsonLd()} />

--- a/src/app/mapa/page.tsx
+++ b/src/app/mapa/page.tsx
@@ -1,4 +1,4 @@
-import { getMembersByYear, getAvailableYears } from "@/data/get-members";
+import { getMembersByYear, getCachedAvailableYears } from "@/data/get-members";
 import { MapaClient } from "./mapa-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function MapaPage({ searchParams }: Props) {
   const { ano } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
   const validAno = ano && isValidYear(ano) ? ano : undefined;
   const currentYear = validAno || (availableYears.find((y) => y.value === "2025")?.value) || (availableYears.length > 0 ? availableYears[0].value : "2025");
   const members = getMembersByYear(currentYear);

--- a/src/app/orgao/[slug]/page.tsx
+++ b/src/app/orgao/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getMembersByYear, getAvailableYears } from "@/data/get-members";
+import { getMembersByYear, getCachedAvailableYears } from "@/data/get-members";
 import { OrgaoDetailClient } from "./orgao-detail-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function OrgaoPage({ searchParams }: Props) {
   const { ano } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
   const validAno = ano && isValidYear(ano) ? ano : undefined;
   const currentYear =
     validAno ||

--- a/src/app/orgao/page.tsx
+++ b/src/app/orgao/page.tsx
@@ -1,4 +1,4 @@
-import { getMembersByYear, getAvailableYears } from "@/data/get-members";
+import { getMembersByYear, getCachedAvailableYears } from "@/data/get-members";
 import { OrgaoListClient } from "./orgao-list-client";
 
 interface Props {
@@ -11,7 +11,7 @@ function isValidYear(ano: string): boolean {
 
 export default async function OrgaosPage({ searchParams }: Props) {
   const { ano } = await searchParams;
-  const availableYears = getAvailableYears();
+  const availableYears = await getCachedAvailableYears();
   const validAno = ano && isValidYear(ano) ? ano : undefined;
   const currentYear = validAno || (availableYears.find((y) => y.value === "2025")?.value) || (availableYears.length > 0 ? availableYears[0].value : "2025");
   const members = getMembersByYear(currentYear);

--- a/src/components/share-buttons.tsx
+++ b/src/components/share-buttons.tsx
@@ -12,11 +12,13 @@ interface ShareButtonsProps {
 export function ShareButtons({ url, title, text }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
   const [currentUrl, setCurrentUrl] = useState(url || "");
+  const [nativeShareSupported, setNativeShareSupported] = useState(false);
 
   useEffect(() => {
     if (!url) {
       setCurrentUrl(window.location.href);
     }
+    setNativeShareSupported(typeof navigator !== "undefined" && "share" in navigator);
   }, [url]);
 
   const shareUrl = currentUrl;
@@ -48,7 +50,7 @@ export function ShareButtons({ url, title, text }: ShareButtonsProps) {
 
   return (
     <div className="flex items-center gap-1.5">
-      {typeof navigator !== "undefined" && "share" in navigator && (
+      {nativeShareSupported && (
         <button
           onClick={handleNativeShare}
           className="flex items-center gap-1.5 rounded-md bg-navy px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-navy/90"

--- a/src/components/site-nav.tsx
+++ b/src/components/site-nav.tsx
@@ -13,18 +13,20 @@ import {
   Info,
   Menu,
   X,
+  TrendingUp,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import { useState } from "react";
 
 const NAV_GROUPS = [
-  {
+{
     label: "Dados",
     links: [
       { href: "/", label: "Ranking", icon: Trophy },
       { href: "/mapa", label: "Mapa", icon: Map },
       { href: "/estatisticas", label: "Estatísticas", icon: BarChart3 },
+      { href: "/comparativo", label: "Comparativo", icon: TrendingUp },
       { href: "/orgao", label: "Órgãos", icon: Building2 },
       { href: "/anomalias", label: "Anomalias", icon: AlertTriangle },
     ],

--- a/src/data/get-members.ts
+++ b/src/data/get-members.ts
@@ -482,3 +482,30 @@ export const getCachedAllYearsTrend = unstable_cache(
   ["all-years-trend"],
   { revalidate: 600 }
 );
+
+export function getYearMonthCounts(): { year: number; monthCount: number }[] {
+  try {
+    const db = openDB();
+    if (!db) return [];
+
+    const rows = db
+      .prepare(
+        `SELECT ano_referencia as year, COUNT(DISTINCT mes_referencia) as monthCount
+         FROM membros
+         GROUP BY ano_referencia
+         ORDER BY ano_referencia`
+      )
+      .all() as { year: number; monthCount: number }[];
+
+    db.close();
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+export const getCachedYearMonthCounts = unstable_cache(
+  async () => getYearMonthCounts(),
+  ["year-month-counts"],
+  { revalidate: 600 }
+);

--- a/src/data/get-members.ts
+++ b/src/data/get-members.ts
@@ -3,6 +3,7 @@
  * falling back to mock data for development.
  */
 
+import { unstable_cache } from "next/cache";
 import type { Member } from "./mock-data";
 import { getKPIs } from "./mock-data";
 import { TETO_CONSTITUCIONAL, type Cargo } from "@/lib/constants";
@@ -256,7 +257,7 @@ export interface YearComparisonData {
   averageAboveTeto: number;
   averageTotalRemuneration: number;
   topOrgans: { orgao: string; total: number }[];
-  topState: { estado: string; total: number };
+  topState: { estado: string; total: number } | null;
 }
 
 export interface Anomalia {
@@ -365,8 +366,7 @@ function getYearAggregates(year: number): YearComparisonData | null {
          FROM membros
          WHERE ano_referencia = ? AND acima_teto > 0
          GROUP BY orgao
-         ORDER BY total DESC
-         LIMIT 5`
+         ORDER BY total DESC`
       )
       .all(year) as { orgao: string; total: number }[];
 
@@ -434,20 +434,51 @@ export function getAllYearsTrend(): YearComparisonData[] {
     const db = openDB();
     if (!db) return [];
 
-    const years = db
-      .prepare("SELECT DISTINCT ano_referencia FROM membros ORDER BY ano_referencia")
-      .all() as { ano_referencia: number }[];
-
-    const results: YearComparisonData[] = [];
-
-    for (const { ano_referencia } of years) {
-      const agg = getYearAggregates(ano_referencia);
-      if (agg) results.push(agg);
-    }
+    const rows = db.prepare(`
+      SELECT 
+        ano_referencia as year,
+        COUNT(DISTINCT nome || '-' || orgao) as totalMembers,
+        SUM(CASE WHEN acima_teto > 0 THEN 1 ELSE 0 END) as membersAboveTeto,
+        SUM(acima_teto) as totalAboveTeto,
+        AVG(CASE WHEN acima_teto > 0 THEN acima_teto END) as averageAboveTeto,
+        AVG(remuneracao_total) as averageTotalRemuneration
+      FROM membros
+      GROUP BY ano_referencia
+      ORDER BY ano_referencia
+    `).all() as {
+      year: number;
+      totalMembers: number;
+      membersAboveTeto: number;
+      totalAboveTeto: number;
+      averageAboveTeto: number;
+      averageTotalRemuneration: number;
+    }[];
 
     db.close();
-    return results;
+
+    return rows.map((row) => ({
+      year: row.year,
+      totalMembers: row.totalMembers || 0,
+      membersAboveTeto: row.membersAboveTeto || 0,
+      totalAboveTeto: row.totalAboveTeto || 0,
+      averageAboveTeto: row.averageAboveTeto || 0,
+      averageTotalRemuneration: row.averageTotalRemuneration || 0,
+      topOrgans: [],
+      topState: null,
+    }));
   } catch {
     return [];
   }
 }
+
+export const getCachedAvailableYears = unstable_cache(
+  async () => getAvailableYears(),
+  ["available-years"],
+  { revalidate: 600 }
+);
+
+export const getCachedAllYearsTrend = unstable_cache(
+  async () => getAllYearsTrend(),
+  ["all-years-trend"],
+  { revalidate: 600 }
+);

--- a/src/data/get-members.ts
+++ b/src/data/get-members.ts
@@ -248,6 +248,17 @@ export function getDataMonth(mesReferencia?: string): string {
   }
 }
 
+export interface YearComparisonData {
+  year: number;
+  totalMembers: number;
+  membersAboveTeto: number;
+  totalAboveTeto: number;
+  averageAboveTeto: number;
+  averageTotalRemuneration: number;
+  topOrgans: { orgao: string; total: number }[];
+  topState: { estado: string; total: number };
+}
+
 export interface Anomalia {
   nome: string;
   cargo: string;
@@ -320,6 +331,123 @@ export function getAnomalias(ano: number, minVariacaoPct = 200): Anomalia[] {
     }));
   } catch (err) {
     console.error("getAnomalias error:", err);
+    return [];
+  }
+}
+
+function getYearAggregates(year: number): YearComparisonData | null {
+  try {
+    const db = openDB();
+    if (!db) return null;
+
+    const rows = db
+      .prepare(
+        `SELECT
+          COUNT(DISTINCT nome || '-' || orgao) as total_members,
+          SUM(CASE WHEN acima_teto > 0 THEN 1 ELSE 0 END) as members_above_teto,
+          SUM(acima_teto) as total_above_teto,
+          AVG(CASE WHEN acima_teto > 0 THEN acima_teto END) as average_above_teto,
+          AVG(remuneracao_total) as average_total_remuneration
+        FROM membros
+        WHERE ano_referencia = ?`
+      )
+      .get(year) as {
+        total_members: number;
+        members_above_teto: number;
+        total_above_teto: number;
+        average_above_teto: number;
+        average_total_remuneration: number;
+      } | undefined;
+
+    const topOrgansRows = db
+      .prepare(
+        `SELECT orgao, SUM(acima_teto) as total
+         FROM membros
+         WHERE ano_referencia = ? AND acima_teto > 0
+         GROUP BY orgao
+         ORDER BY total DESC
+         LIMIT 5`
+      )
+      .all(year) as { orgao: string; total: number }[];
+
+    const topStateRow = db
+      .prepare(
+        `SELECT estado, SUM(acima_teto) as total
+         FROM membros
+         WHERE ano_referencia = ? AND acima_teto > 0
+         GROUP BY estado
+         ORDER BY total DESC
+         LIMIT 1`
+      )
+      .get(year) as { estado: string; total: number } | undefined;
+
+    db.close();
+
+    if (!rows) return null;
+
+    return {
+      year,
+      totalMembers: rows.total_members || 0,
+      membersAboveTeto: rows.members_above_teto || 0,
+      totalAboveTeto: rows.total_above_teto || 0,
+      averageAboveTeto: rows.average_above_teto || 0,
+      averageTotalRemuneration: rows.average_total_remuneration || 0,
+      topOrgans: topOrgansRows.map((r) => ({ orgao: r.orgao, total: r.total })),
+      topState: topStateRow ? { estado: topStateRow.estado, total: topStateRow.total } : { estado: "", total: 0 },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getYearComparison(year1: number, year2: number): {
+  year1: YearComparisonData;
+  year2: YearComparisonData;
+  growth: {
+    membersAboveTeto: number;
+    totalAboveTeto: number;
+    averageAboveTeto: number;
+  };
+} | null {
+  const y1 = getYearAggregates(year1);
+  const y2 = getYearAggregates(year2);
+
+  if (!y1 || !y2) return null;
+
+  const growth = {
+    membersAboveTeto: y1.membersAboveTeto > 0
+      ? ((y2.membersAboveTeto - y1.membersAboveTeto) / y1.membersAboveTeto) * 100
+      : 0,
+    totalAboveTeto: y1.totalAboveTeto > 0
+      ? ((y2.totalAboveTeto - y1.totalAboveTeto) / y1.totalAboveTeto) * 100
+      : 0,
+    averageAboveTeto: y1.averageAboveTeto > 0
+      ? ((y2.averageAboveTeto - y1.averageAboveTeto) / y1.averageAboveTeto) * 100
+      : 0,
+  };
+
+  return { year1: y1, year2: y2, growth };
+}
+
+export function getAllYearsTrend(): YearComparisonData[] {
+  try {
+    const db = openDB();
+    if (!db) return [];
+
+    const years = db
+      .prepare("SELECT DISTINCT ano_referencia FROM membros ORDER BY ano_referencia")
+      .all() as { ano_referencia: number }[];
+
+    const results: YearComparisonData[] = [];
+
+    for (const { ano_referencia } of years) {
+      const agg = getYearAggregates(ano_referencia);
+      if (agg) results.push(agg);
+    }
+
+    db.close();
+    return results;
+  } catch {
     return [];
   }
 }


### PR DESCRIPTION
## Nova página /comparativo para comparação salarial entre diferentes anos

Nova funcionalidade que permite aos usuários comparar dados salariais de servidores públicos entre dois anos diferentes. Inclui:

- **Seletor de anos** com estado na URL (`?ano1=2023&ano2=2024`) para compartilhamento fácil
- **Gráfico de tendência histórica** mostrando a evolução dos totais acima do teto salarial
- **Cards de KPI** comparando: Total Acima do Teto, Membros Acima do Teto, Média por Membro e Crescimento Total
- **Gráficos de barra de comparação** para análise visual ano a ano
- **Tabela de órgãos ordenável** com variação percentual entre os anos
- **Alertas de anos incompletos** quando os dados têm menos de 12 meses
- **Botões de compartilhamento** para redes sociais
