### PR TITLE
fix: corrigir rebuild do índice FTS5 e adicionar script db:fresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 # database (WAL/SHM são temporários, o .db é commitado pelo cron-sync)
-/data/*.db-wal
-/data/*.db-shm
+/data/*
 
 # playwright
 /test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -5866,6 +5866,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "db:fresh": "tsx scripts/sync-data.ts --fresh",
     "db:seed": "tsx scripts/sync-data.ts --seed",
     "db:sync": "tsx scripts/sync-data.ts",
     "test": "vitest run",

--- a/scripts/sync-data.ts
+++ b/scripts/sync-data.ts
@@ -584,19 +584,30 @@ async function syncAll(year: number, month: number, force: boolean) {
   console.log(`Month: ${mesRef}\n`);
 }
 
+function freshDb() {
+  sqlite.exec(`
+    DELETE FROM historico_mensal;
+    DELETE FROM membros;
+    DELETE FROM sync_log;
+  `);
+  sqlite.exec(`INSERT INTO membros_fts(membros_fts) VALUES('rebuild')`);
+  console.log("Database cleared.");
+}
+
 function rebuildFTS() {
   console.log("Rebuilding FTS index...");
-  sqlite.exec(`
-    DELETE FROM membros_fts;
-    INSERT INTO membros_fts(rowid, nome, cargo, orgao)
-      SELECT id, nome, cargo, orgao FROM membros;
-  `);
+  sqlite.exec(`INSERT INTO membros_fts(membros_fts) VALUES('rebuild')`);
   console.log("FTS index rebuilt.\n");
 }
 
 // CLI
 async function main() {
   const args = process.argv.slice(2);
+
+  if (args.includes("--fresh")) {
+    freshDb();
+    return;
+  }
 
   if (args.includes("--seed")) {
     await seedWithMockData();


### PR DESCRIPTION
Minha primeira contribuição em um projeto open-source.

## Problema

A função `rebuildFTS()` usava `DELETE FROM membros_fts` seguido de um `INSERT` manual para reconstruir o índice de busca. Porém, `membros_fts` é uma **external content table** do FTS5 — ela não armazena cópias dos dados, apenas o índice, referenciando a tabela `membros`.

Ao executar `DELETE FROM membros_fts`, o SQLite tenta buscar o conteúdo original em `membros` para desfazer as entradas do índice de forma consistente. Quando os dados já foram removidos (ou não coincidem), isso resulta no erro:

```sh
extrateto % npm run db:seed

> extrateto@0.1.0 db:seed
> tsx scripts/sync-data.ts --seed

Seeding database with mock data...
Rebuilding FTS index...
SqliteError: database disk image is malformed
    at Database.exec (/Users/tiago.castro/projetos/extrateto/node_modules/better-sqlite3/lib/methods/wrappers.js:9:14)
    at rebuildFTS (/Users/tiago.castro/projetos/extrateto/scripts/sync-data.ts:589:10)
    at seedWithMockData (/Users/tiago.castro/projetos/extrateto/scripts/sync-data.ts:524:3)
    at async main (/Users/tiago.castro/projetos/extrateto/scripts/sync-data.ts:602:5) {
  code: 'SQLITE_CORRUPT_VTAB'
}
```

> Reproduzível ao rodar `npm run db:seed` com o banco já populado.

## Solução

Substituir o `DELETE + INSERT` manual pelo comando nativo do FTS5:

```sql
INSERT INTO membros_fts(membros_fts) VALUES('rebuild');
```

## Mudanças
- [X] Adicionei o comando `npm run db:fresh` em `scripts/sync-data.ts` para limpar o banco de dados
- [X] Ajustei o `.gitignore` para também não tracker o `extrateto.sql`