### PR TITLE
a11y: skip-link, landmarks semânticos e ARIA na navegação

### DIFF
--- a/src/app/anomalias/anomalias-client.tsx
+++ b/src/app/anomalias/anomalias-client.tsx
@@ -179,7 +179,7 @@ export function AnomaliasClient({
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
@@ -532,7 +532,7 @@ export function AnomaliasClient({
             </div>
           )}
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -38,7 +38,7 @@ const endpoints = [
 export default function ApiDocsPage() {
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6">
+      <main id="main-content" className="mx-auto max-w-4xl px-4 py-12 sm:px-6">
         <Link
           href="/"
           className="mb-8 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -166,7 +166,7 @@ export default function ApiDocsPage() {
 }`}</pre>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/comparativo/comparativo-client.tsx
+++ b/src/app/comparativo/comparativo-client.tsx
@@ -227,7 +227,7 @@ export function ComparativoClient({
   if (!comparison) {
     return (
       <div className="min-h-screen bg-background">
-        <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
           <Link
             href="/"
             className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -238,7 +238,7 @@ export function ComparativoClient({
           <div className="rounded-lg border border-gray-100 bg-white p-8 text-center">
             <p className="text-gray-500">Dados não disponíveis para comparação.</p>
           </div>
-        </div>
+        </main>
         <Footer />
       </div>
     );
@@ -246,7 +246,7 @@ export function ComparativoClient({
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           href="/"
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -610,7 +610,7 @@ export function ComparativoClient({
             </button>
           )}
         </section>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/estatisticas/estatisticas-client.tsx
+++ b/src/app/estatisticas/estatisticas-client.tsx
@@ -194,7 +194,7 @@ export function EstatisticasClient({
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           href="/"
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -420,7 +420,7 @@ export function EstatisticasClient({
             Valores aproximados.
           </p>
         </section>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -105,7 +105,7 @@ export function HomeClient({ members, dataMonth, availableMonths, currentMonth }
         dataMonth={dataMonth}
       />
 
-      <main className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
         {/* KPIs */}
         <section className="mb-6">
           <KPICards data={kpis} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,6 +68,12 @@ export default function RootLayout({
       >
         <JsonLd data={getWebsiteJsonLd()} />
         <JsonLd data={getDatasetJsonLd()} />
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:rounded"
+        >
+          Pular para o conteúdo
+        </a>
         <SiteNav />
         <div className="pt-12 lg:pl-56 lg:pt-0">
           {children}

--- a/src/app/mapa/mapa-client.tsx
+++ b/src/app/mapa/mapa-client.tsx
@@ -63,7 +63,7 @@ export function MapaClient({ members, availableYears, currentYear }: MapaClientP
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           href="/"
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -184,7 +184,7 @@ export function MapaClient({ members, availableYears, currentYear }: MapaClientP
             </div>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/metodologia/page.tsx
+++ b/src/app/metodologia/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/footer";
 export default function MetodologiaPage() {
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+      <main id="main-content" className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
         <Link
           href="/"
           className="mb-8 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -161,7 +161,7 @@ export default function MetodologiaPage() {
             </ul>
           </section>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/orgao/[slug]/orgao-detail-client.tsx
+++ b/src/app/orgao/[slug]/orgao-detail-client.tsx
@@ -108,7 +108,7 @@ export function OrgaoDetailClient({ members, availableYears, currentYear }: Orga
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           href={`/orgao?ano=${currentYear}`}
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -364,7 +364,7 @@ export function OrgaoDetailClient({ members, availableYears, currentYear }: Orga
             </table>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/orgao/orgao-list-client.tsx
+++ b/src/app/orgao/orgao-list-client.tsx
@@ -98,7 +98,7 @@ export function OrgaoListClient({ members, availableYears, currentYear }: OrgaoL
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           href="/"
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -247,7 +247,7 @@ export function OrgaoListClient({ members, availableYears, currentYear }: OrgaoL
             </p>
           )}
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/footer";
 export default function SobrePage() {
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+      <main id="main-content" className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
         <Link
           href="/"
           className="mb-8 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-navy"
@@ -72,7 +72,7 @@ export default function SobrePage() {
             </p>
           </section>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/components/member-profile.tsx
+++ b/src/components/member-profile.tsx
@@ -71,7 +71,7 @@ export function MemberProfileView({ member }: { member: MemberProfile }) {
 
   return (
     <div className="min-h-screen bg-gray-50/30">
-      <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6 sm:py-8">
+      <main id="main-content" className="mx-auto max-w-4xl px-4 py-6 sm:px-6 sm:py-8">
         {/* Back */}
         <Link
           href="/"
@@ -458,7 +458,7 @@ export function MemberProfileView({ member }: { member: MemberProfile }) {
           </a>{" "}
           · Referência: {formatMonthLabel(member.mesRecente)}
         </p>
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/components/site-nav.tsx
+++ b/src/components/site-nav.tsx
@@ -51,6 +51,8 @@ export function SiteNav() {
       <div className="fixed left-0 right-0 top-0 z-50 flex h-12 items-center border-b border-gray-100 bg-white px-4 lg:hidden">
         <button
           onClick={() => setMobileOpen(!mobileOpen)}
+          aria-label={mobileOpen ? "Fechar menu" : "Abrir menu"}
+          aria-expanded={mobileOpen}
           className="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100"
         >
           {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -64,6 +66,7 @@ export function SiteNav() {
       {/* Mobile overlay */}
       {mobileOpen && (
         <div
+          aria-hidden="true"
           className="fixed inset-0 z-40 bg-black/30 lg:hidden"
           onClick={() => setMobileOpen(false)}
         />
@@ -71,6 +74,7 @@ export function SiteNav() {
 
       {/* Sidebar */}
       <nav
+        aria-label="Navegação principal"
         className={cn(
           "fixed left-0 top-0 z-40 flex h-full w-56 flex-col border-r border-gray-100 bg-white transition-transform duration-200 lg:translate-x-0",
           mobileOpen ? "translate-x-0" : "-translate-x-full"


### PR DESCRIPTION
Resolve #14

## Problema

O projeto não possuía mecanismos básicos de acessibilidade na navegação:

- Usuários de teclado precisavam percorrer todos os links da sidebar antes de
  acessar o conteúdo principal
- Nenhuma rota usava a landmark `<main>`, impedindo navegação por landmarks em
  leitores de tela
- O botão hamburguer mobile não anunciava sua função nem seu estado
- O overlay de fundo do menu mobile era lido desnecessariamente por leitores de tela
- O `<nav>` não tinha nome acessível

## O que foi alterado

### `src/app/layout.tsx`
Adicionado link "Pular para o conteúdo" como primeiro elemento focável do layout.
Visualmente oculto com `sr-only`, aparece ao receber foco via teclado.

### `src/components/site-nav.tsx`
- `<nav>`: adicionado `aria-label="Navegação principal"`
- Botão hamburguer: adicionado `aria-label` dinâmico ("Abrir menu" / "Fechar menu")
  e `aria-expanded`
- Overlay mobile: adicionado `aria-hidden="true"`

### 11 arquivos — `<div>` container → `<main id="main-content">`

| Arquivo | Rota |
|---|---|
| `src/app/home-client.tsx` | `/` |
| `src/app/anomalias/anomalias-client.tsx` | `/anomalias` |
| `src/app/comparativo/comparativo-client.tsx` | `/comparativo` |
| `src/app/estatisticas/estatisticas-client.tsx` | `/estatisticas` |
| `src/app/mapa/mapa-client.tsx` | `/mapa` |
| `src/app/orgao/orgao-list-client.tsx` | `/orgao` |
| `src/app/orgao/[slug]/orgao-detail-client.tsx` | `/orgao/[slug]` |
| `src/app/api-docs/page.tsx` | `/api-docs` |
| `src/app/metodologia/page.tsx` | `/metodologia` |
| `src/app/sobre/page.tsx` | `/sobre` |
| `src/components/member-profile.tsx` | `/membro/[orgao]/[slug]` |

## Critérios WCAG atendidos

| Critério | Nível | O que resolve |
|---|---|---|
| 2.4.1 Bypass Blocks | A | Skip-link + `<main id="main-content">` |
| 1.3.1 Info and Relationships | A | Landmark `<main>` semântico em todas as rotas |
| 4.1.2 Name, Role, Value | A | `aria-label` e `aria-expanded` no hamburguer; `aria-label` no `<nav>` |

## Mudança visual

Nenhuma. O skip-link só é visível ao receber foco via teclado.

## Como testar

**Skip-link**
1. Abra qualquer página e pressione `Tab` uma vez
2. O link "Pular para o conteúdo" deve aparecer no canto superior esquerdo
3. Pressione `Enter` — o foco deve saltar direto para o conteúdo, ignorando a sidebar

**Landmarks (VoiceOver: `VO+U` / NVDA: `Insert+F7`)**
1. Abra o rotor/lista de landmarks
2. Devem aparecer: `main` e `navigation "Navegação principal"`

**Menu mobile** (viewport < 1024px)
1. Navegue até o botão hamburguer via `Tab`
2. O leitor de tela deve anunciar "Abrir menu"
3. Pressione `Enter` para abrir — deve anunciar "Fechar menu"
4. O overlay de fundo não deve ser lido pelo leitor de tela
